### PR TITLE
Feat: Build and style SingleIssuePage

### DIFF
--- a/src/pages/SingleIssuePage/SingleIssuePage.module.scss
+++ b/src/pages/SingleIssuePage/SingleIssuePage.module.scss
@@ -1,0 +1,115 @@
+@use '@styles/tokens/typography' as *;
+@use '@styles/abstracts/mixins' as *;
+
+.singleIssuePage {
+  @include wrapper;
+  padding-inline: var(--space-fluid);
+  padding-block: var(--space-m);
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+
+  @include mq(md) {
+    padding-block: 0;
+    padding-bottom: var(--space-2xl);
+  }
+}
+
+.coverWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+
+  @include mq(md) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+  }
+}
+
+.coverButton {
+  @include mq(md) {
+    grid-row: 2;
+    align-self: start;
+    justify-self: end;
+    margin-right: clamp(3%, 51.34vw - 379px, 25%);
+  }
+}
+.cover {
+  grid-row: 1 / -1;
+}
+
+.contentsWrapper {
+  display: flex;
+  flex-direction: column;
+  align-self: end;
+}
+
+.playList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-s);
+
+  font-size: var(--text-500);
+
+  @include mq(md) {
+    max-width: 24.3rem;
+  }
+}
+
+.playListRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+
+  @include mq(md) {
+    grid-template-columns: 1fr auto;
+  }
+
+  dd {
+    text-align: right;
+  }
+}
+
+.title {
+  font-family: $font-serif;
+  padding-left: var(--space-s);
+  padding-bottom: var(--space-m);
+
+  @include mq(md) {
+    padding-inline: var(--space-xl);
+  }
+}
+
+.prefaceWrapper {
+  display: flex;
+  flex-direction: column;
+
+  @include mq(md) {
+    padding-inline: var(--space-2xl);
+    align-self: center;
+  }
+
+  @include mq(lg) {
+    max-width: 90%;
+    align-self: center;
+  }
+}
+
+.prefaceBody {
+  line-height: 1.375;
+
+  @include mq(md) {
+    display: block;
+    column-count: 2;
+    column-gap: 10%;
+  }
+}
+
+.prefaceButton {
+  margin-block: var(--space-2xl);
+
+  @include mq(lg) {
+    display: none;
+  }
+}

--- a/src/pages/SingleIssuePage/SingleIssuePage.tsx
+++ b/src/pages/SingleIssuePage/SingleIssuePage.tsx
@@ -1,6 +1,58 @@
+import { IssueCover } from '@/components/IssueCover';
 import styles from './SingleIssuePage.module.scss';
 import classNames from 'classnames';
+import { Button } from '@/components/Button';
+import { useIssues } from '@/hooks/useIssues';
+import { useParams } from 'react-router';
 
 export const SingleIssuePage = () => {
-  return <div className={classNames(styles.singleIssuePage)}></div>;
+  const { id } = useParams();
+  const { issues } = useIssues();
+
+  const issue = issues.find((i) => i.acf.issue_number.toString() === id);
+
+  if (!issue) {
+    return (
+      <div className={classNames(styles.singleIssuePage, styles.notFound)}>
+        <h2>Oh oh!</h2>
+        <p>The issue you are looking for cannot be found.</p>
+        <p>Please refresh the page or come back later.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={classNames(styles.singleIssuePage)}>
+      <div className={styles.coverWrapper}>
+      <IssueCover
+        issueNumber={issue.acf.issue_number}
+        theme={issue.acf.theme}
+        className={styles.cover}
+      />
+      <Button className={styles.coverButton}>Beställ numret</Button>
+
+      {issue.acf.content && (
+        <div className={styles.contentsWrapper}>
+          <h2 className={styles.title}>Innehåll</h2>
+          <dl className={styles.playList}>
+            {issue.acf.content.map((content) => (
+              <div key={content.play} className={styles.playListRow}>
+                <dt>{content.play}</dt>
+                <dd>{content.playwright}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      )}
+      </div>
+
+      {issue.acf.preface && (
+        <div className={styles.prefaceWrapper}>
+          <h2 className={styles.title}>Förord</h2>
+          <p className={styles.prefaceBody}>{issue.acf.preface}</p>
+          <Button className={styles.prefaceButton}>Beställ numret</Button>
+        </div>
+      )}
+    </div>
+  );
 };


### PR DESCRIPTION
## 📝 Summary of Changes

Implements components `IssueCover` and fix styling and layout of entire `SingleIssuePage`. Checks params and renders correct issue accordingly. 

### This PR primarily:

- **Implements:** 
  - _Adds the `IssueCover` to `SingleIssuePage` and display all contents._
  - _Styles entire `SingleIssuePage`_

**Related Issue:**
- [Build current issue view](https://github.com/users/matildasoderhall/projects/3/views/1?pane=issue&itemId=146433092&issue=matildasoderhall%7Crumfordramatik%7C9)