### PR TITLE
Fix: Premature 404 rendering on SinglePageIssuePage

### DIFF
--- a/src/pages/SingleIssuePage/SingleIssuePage.module.scss
+++ b/src/pages/SingleIssuePage/SingleIssuePage.module.scss
@@ -9,6 +9,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-xl);
+  align-items: center;
 
   @include mq(md) {
     padding-block: 0;

--- a/src/pages/SingleIssuePage/SingleIssuePage.tsx
+++ b/src/pages/SingleIssuePage/SingleIssuePage.tsx
@@ -7,19 +7,25 @@ import { Link, useParams } from 'react-router';
 import { DecorativeArrow, ArrowType } from '@/components/DecorativeArrow';
 import { FormattedText } from '@/components/FormattedText';
 import { SEO } from '@/components/SEO';
+import { NotFoundPage } from '../NotFoundPage';
+import { Spinner } from '@/components/Spinner';
 
 export const SingleIssuePage = () => {
   const { id } = useParams();
-  const { issues } = useIssues();
+  const { issues, loading } = useIssues();
 
   const issue = issues.find((i) => i.acf.issue_number.toString() === id);
 
+  if (loading) {
+    return <div className={classNames(styles.singleIssuePage)}>
+        <Spinner />
+      </div>;
+  }
+
   if (!issue) {
     return (
-      <div className={classNames(styles.singleIssuePage, styles.notFound)}>
-        <h2>Oh oh!</h2>
-        <p>The issue you are looking for cannot be found.</p>
-        <p>Please refresh the page or come back later.</p>
+      <div className={classNames(styles.singleIssuePage)}>
+        <NotFoundPage />
       </div>
     );
   }


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes a logic bug where the "Not Found" state was rendering prematurely. By reordering the guard clauses, the component now correctly waits for the data fetch to complete before determining if the content is missing.

### This PR primarily:

* **Updates:**
* *Prioritises the `loading` state check to prevent a "flash of 404" or premature redirect.*
* *Ensures `Spinner` is rendered while data is being fetched.*
* *Renders `NotFoundPage` only when loading is complete and no issue data is returned.*



**Related Issue:**

* [Fix issues #4](https://github.com/users/matildasoderhall/projects/3/views/1?pane=issue&itemId=152968658&issue=matildasoderhall%7Crumfordramatik%7C47)
