### PR TITLE
Feat: Add Global Error Boundary for Graceful Crash Handling`

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,6 +9,7 @@ import { SignUpPage } from './pages/SignUpPage';
 import { SingleIssuePage } from './pages/SingleIssuePage';
 import { PrivacyPolicyPage } from './pages/PrivacyPolicyPage';
 import { OrderPage } from './pages/OrderPage';
+import { ErrorPage } from './pages/ErrorPage';
 
 export const appRouter = createBrowserRouter([
   {
@@ -52,6 +53,6 @@ export const appRouter = createBrowserRouter([
         element: <NotFoundPage />,
       },
     ],
-    errorElement: '', //TODO: Add default ErrorPage
+    errorElement: <ErrorPage />,
   },
 ]);

--- a/src/pages/ErrorPage/ErrorPage.module.scss
+++ b/src/pages/ErrorPage/ErrorPage.module.scss
@@ -1,0 +1,62 @@
+@use '@styles/tokens/typography' as *;
+
+.errorPageWrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  
+
+  .content {
+    width: 100%;
+    max-width: 40rem; 
+    margin: 0 auto;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: var(--space-s);
+  }
+
+  .errorCode {
+    font-size: var(--fs-900);
+    font-family: $font-condensed;
+    line-height: 1;
+    color: var(--color-primary);
+    display: block;
+    margin-bottom: var(--space-s);
+  }
+
+  h1 {
+    font-size: var(--fs-600);
+    margin-bottom: var(--space-m);
+  }
+
+  p {
+    font-size: var(--fs-400);
+    margin-bottom: var(--space-xl);
+    color: var(--color-text-muted);
+  }
+
+  .homeButton {
+    display: inline-block;
+    padding: var(--space-s) var(--space-l);
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    text-transform: uppercase;
+    text-decoration: none;
+    font-family: $font-condensed;
+    font-size: 2rem;
+    transition: transform 0.4s cubic-bezier(0.2, 0.8, 0.2, 1);
+
+    &:hover {
+      background-color: var(--color-primary-hover);
+      transform: scale(1.02);
+    }
+  }
+
+  .techDetails {
+    color: var(--color-black-transparent-md);
+  }
+}

--- a/src/pages/ErrorPage/ErrorPage.tsx
+++ b/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,0 +1,31 @@
+import { isRouteErrorResponse, Link, useRouteError } from 'react-router';
+import styles from './ErrorPage.module.scss';
+import { Header } from '@/layouts/Header';
+import { Footer } from '@/layouts/Footer';
+
+export const ErrorPage = () => {
+  const error = useRouteError();
+  const errorMessage = isRouteErrorResponse(error)
+    ? `${error.status} ${error.statusText}`
+    : error instanceof Error
+      ? error.message
+      : 'Unknown error';
+
+  return (
+    <div className={styles.errorPageWrapper}>
+      <Header />
+      <div className={styles.content}>
+        <h1>Vi verkar ha tappat manus!</h1>
+        <p>
+          En oförutsedd vändning har skett och systemet vet inte vad nästa
+          replik är. Prova att ladda om sidan.
+        </p>
+        <p className={styles.techDetails}>Felkod: {errorMessage}</p>
+        <Link to={'/'} className={styles.homeButton}>
+          Tillbaka till startsidan
+        </Link>
+      </div>
+      <Footer />
+    </div>
+  );
+};

--- a/src/pages/ErrorPage/index.ts
+++ b/src/pages/ErrorPage/index.ts
@@ -1,0 +1,1 @@
+export { ErrorPage } from './ErrorPage';


### PR DESCRIPTION
## 📝 Summary of Changes

Introduces a global error boundary to catch application crashes (500 errors) and prevent the "white screen of death." This ensures users always have a way to navigate back to safety, even if a critical code error occurs.

### This PR primarily:

**Implements:**
* *Adds `ErrorPage` component with custom theatrical copy ("Vi verkar ha tappat manus") to match the brand voice.*
* *Configures `errorElement` in `appRouter` to catch root-level exceptions.*
* *Manually imports `Header` and `Footer` into the error view to maintain navigation when the main layout unmounts.*
* *Adds responsive SCSS styling for the error page that ensures the footer sticks to the bottom and the content centers correctly.*



**Related Issue:**

* [Add error page](https://github.com/users/matildasoderhall/projects/3/views/1?pane=issue&itemId=153081452&issue=matildasoderhall%7Crumfordramatik%7C53)